### PR TITLE
Add simple frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# HIS_Ticketing
+# HIS Ticketing
+
+A simple ticket management tool backed by Supabase.
+
+## Setup
+
+1. Create a Supabase project and run `supabase/schema.sql` to set up the database.
+2. Update `frontend/app.js` with your Supabase URL and anon key.
+
+## Usage
+
+Open `frontend/index.html` in your browser. Tickets will load from your Supabase backend.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,28 @@
+const SUPABASE_URL = 'YOUR_SUPABASE_URL';
+const SUPABASE_ANON_KEY = 'YOUR_SUPABASE_ANON_KEY';
+
+const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+async function loadTickets() {
+  const { data: tickets, error } = await supabase
+    .from('tickets')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  const container = document.getElementById('tickets');
+  container.innerHTML = '';
+
+  if (error) {
+    container.textContent = 'Error loading tickets';
+    return;
+  }
+
+  tickets.forEach(t => {
+    const div = document.createElement('div');
+    div.className = 'ticket';
+    div.innerHTML = `<strong>${t.title}</strong><p>${t.description}</p>`;
+    container.appendChild(div);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadTickets);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HIS Ticketing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>HIS Ticketing</h1>
+  </header>
+  <main>
+    <section id="tickets">
+      <!-- Tickets will be loaded here -->
+    </section>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.39.3/dist/umd/supabase.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,31 @@
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 0;
+  background: #f8f9fa;
+  color: #333;
+}
+
+header {
+  padding: 1rem;
+  background: #1e3a8a;
+  color: #fff;
+  text-align: center;
+}
+
+#tickets {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.ticket {
+  border-bottom: 1px solid #ddd;
+  padding: 0.5rem 0;
+}
+
+.ticket:last-child {
+  border-bottom: none;
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,48 @@
+-- Database schema for HIS Ticketing
+
+-- Table: tickets
+create table if not exists tickets (
+    id serial primary key,
+    title text not null,
+    description text,
+    status text default 'open',
+    assigned_to text,
+    created_at timestamp with time zone default now(),
+    updated_at timestamp with time zone default now()
+);
+
+-- Ensure screenshot_url column exists
+alter table tickets add column if not exists screenshot_url text;
+
+-- Function to update updated_at timestamp
+create or replace function update_timestamp()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+-- Trigger: trg_ticket_after_insert
+
+-- Drop existing trigger if present
+ drop trigger if exists trg_ticket_after_insert on tickets;
+create trigger trg_ticket_after_insert
+before insert on tickets
+for each row execute procedure update_timestamp();
+
+-- Trigger: trg_ticket_status_change
+
+-- Drop existing trigger if present
+ drop trigger if exists trg_ticket_status_change on tickets;
+create trigger trg_ticket_status_change
+before update of status on tickets
+for each row execute procedure update_timestamp();
+
+-- Trigger: trg_ticket_assigned
+
+-- Drop existing trigger if present
+ drop trigger if exists trg_ticket_assigned on tickets;
+create trigger trg_ticket_assigned
+before update of assigned_to on tickets
+for each row execute procedure update_timestamp();


### PR DESCRIPTION
## Summary
- create `frontend` directory with index.html, style.css and app.js
- fetch tickets from Supabase and display them
- document basic setup steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68697c8674cc8333983f1586c692b03d